### PR TITLE
fix typo .abcde.conf

### DIFF
--- a/setup/.abcde.conf
+++ b/setup/.abcde.conf
@@ -541,7 +541,7 @@ mungefilename ()
 # Custom filename munging specific to album names:
 # By default this function will call the mungefilename function.
 #
-# Adjust albumname to not overwrite "Unkown Album" folders
+# Adjust albumname to not overwrite "Unknown Album" folders
 # for subsequent unknown discs.
 # 
 ID_SUFFIX=$(cd-discid $CDROM | cut -f1 -d ' ')


### PR DESCRIPTION
fix typo in abcde.conf file

# Description
I fixed a typo in the abcde.conf file

## Type of change
Please delete options that are not relevant.

- [ ] fixed a typo in abcde.conf comment

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration

- [x] Docker
- [ ] Other (Please state here)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested that my fix is effective or that my feature works

# Changelog:

Include the details of changes made here
-fixed a typo in the word unknown in the abcde.conf file
